### PR TITLE
fixed a typo on page 95

### DIFF
--- a/latex/skiplists.tex
+++ b/latex/skiplists.tex
@@ -362,7 +362,7 @@ The next two lemmata tell us that skiplists have linear size:
   \]
   The height, #h#, of the skiplist is then given by
   \[
-       #h# = \sum_{i=1}^\infty I_{#r#} \enspace .
+       #h# = \sum_{r=1}^\infty I_{#r#} \enspace .
   \]
   Note that $I_{#r#}$ is never more than the length, $|L_{#r#}|$, of $L_{#r#}$, so 
   \[


### PR DESCRIPTION
It should be `r` instead of `i` in this sum.
