### PR TITLE
Corrected the expansion of a negative exponent

### DIFF
--- a/latex/intro.tex
+++ b/latex/intro.tex
@@ -713,7 +713,7 @@ For any two random variables $X$ and $Y$,
 \]
 More generally, for any random variables $X_1,\ldots,X_k$,
 \[
-   \E\left[\sum_{i=1}^k X_k\right] = \sum_{i=1}^k \E[X_i] \enspace .
+   \E\left[\sum_{i=1}^k X_i\right] = \sum_{i=1}^k \E[X_i] \enspace .
 \]
 Linearity of expectation allows us to break down complicated random variables (like the left hand sides of the above equations) into sums of simpler random variables (the right hand sides).
 

--- a/latex/intro.tex
+++ b/latex/intro.tex
@@ -413,7 +413,7 @@ multiplied by itself $x-1$ times:
 \[
     b^x = \underbrace{b\times b\times \cdots \times b}_{x} \enspace .
 \]
-When $x$ is a negative integer, $b^x=1/b^{-x}$.  When $x=0$, $b^x=1$.
+When $x$ is a negative integer, $b^{-x}=1/b^{x}$.  When $x=0$, $b^x=1$.
 When $b$ is not an integer, we can still define exponentiation in terms
 of the exponential function $e^x$ (see below), which is itself defined in
 terms of the exponential series, but this is best left to a calculus text.


### PR DESCRIPTION
The original text expands a^(-x) to 1/(a^(-x)). It should expand to 1/(a^x).