### PR TITLE
fixed indentation of cplusplus programs

### DIFF
--- a/cpp/ChainedHashTable.h
+++ b/cpp/ChainedHashTable.h
@@ -48,7 +48,7 @@ template<class T>
 void ChainedHashTable<T>::resize() {
 	d = 1;
 	while (1<<d <= n) d++;
-    n = 0;
+	n = 0;
 	array<List> newTable(1<<d);
 	for (int i = 0; i < t.length; i++) {
 		for (int j = 0; j < t[i].size(); j++) {

--- a/cpp/DLList.h
+++ b/cpp/DLList.h
@@ -111,7 +111,7 @@ T DLList<T>::set(int i, T x) {
 
 template<class T>
 void DLList<T>::add(int i, T x) {
-    addBefore(getNode(i), x);
+	addBefore(getNode(i), x);
 }
 
 template<class T>

--- a/cpp/RootishArrayStack.h
+++ b/cpp/RootishArrayStack.h
@@ -41,25 +41,25 @@ int RootishArrayStack<T>::size() {
 
 template<class T> inline 
 T RootishArrayStack<T>::get(int i) {
-    int b = i2b(i);
-    int j = i - b*(b+1)/2;
-    return blocks.get(b)[j];
+	int b = i2b(i);
+	int j = i - b*(b+1)/2;
+	return blocks.get(b)[j];
 }
 
 template<class T> inline 
 T RootishArrayStack<T>::set(int i, T x) {
-    int b = i2b(i);
-    int j = i - b*(b+1)/2;
-    T y = blocks.get(b)[j];
-    blocks.get(b)[j] = x;
-    return y;
+	int b = i2b(i);
+	int j = i - b*(b+1)/2;
+	T y = blocks.get(b)[j];
+	blocks.get(b)[j] = x;
+	return y;
 }
 
 template<class T> inline 
 int RootishArrayStack<T>::i2b(int i) {
-    double db = (-3.0 + sqrt(9 + 8*i)) / 2.0;
-    int b = (int)ceil(db);
-    return b;
+	double db = (-3.0 + sqrt(9 + 8*i)) / 2.0;
+	int b = (int)ceil(db);
+	return b;
 }
 
 template<class T>  
@@ -73,28 +73,28 @@ RootishArrayStack<T>::~RootishArrayStack() {
 
 template<class T> 
 void RootishArrayStack<T>::add(int i, T x) {
-    int r = blocks.size();
-    if (r*(r+1)/2 < n + 1) grow();
-    n++;
-    for (int j = n-1; j > i; j--)
-            set(j, get(j-1));
-    set(i, x);
+	int r = blocks.size();
+	if (r*(r+1)/2 < n + 1) grow();
+	n++;
+	for (int j = n-1; j > i; j--)
+		set(j, get(j-1));
+	set(i, x);
 }
 
 template<class T>  
 T RootishArrayStack<T>::remove(int i) {
-    T x = get(i);
-    for (int j = i; j < n-1; j++)
-            set(j, get(j+1));
-    n--;
-    int r = blocks.size();
-    if ((r-2)*(r-1)/2 >= n) shrink();
-    return x;
+	T x = get(i);
+	for (int j = i; j < n-1; j++)
+		set(j, get(j+1));
+	n--;
+	int r = blocks.size();
+	if ((r-2)*(r-1)/2 >= n) shrink();
+	return x;
 }
 
 template<class T>  
 void RootishArrayStack<T>::grow() {
-    blocks.add(blocks.size(), new T[blocks.size()+1]);
+	blocks.add(blocks.size(), new T[blocks.size()+1]);
 }
 
 template<class T>

--- a/latex/snarf-cpp.pl
+++ b/latex/snarf-cpp.pl
@@ -113,7 +113,7 @@ sub snarfit($$) {
       # external function definition
       my $sig = methodSig($2, $3);
       # print(STDERR "$line - $sig");
-      if (wanted($sig, @params)) { $print = $d; }
+      if (wanted($sig, @params)) { $print = $d; $indent = "\t"; }
     } elsif ($d == $d0+1 && $inclass == 1 && $line =~ /^\s*$type\s+(\&|\*)*(\w+).*;.*/) {
       # instance or class variable declaration
       if (wanted($3, @params)) {


### PR DESCRIPTION
In ods-cpp.pdf, tabstops in C++ programs are 2, but those in some program are 4.
Fixed snarf-cpp.pl.