### PR TITLE
update ChainedHashTable

### DIFF
--- a/cpp/ChainedHashTable.h
+++ b/cpp/ChainedHashTable.h
@@ -48,7 +48,6 @@ template<class T>
 void ChainedHashTable<T>::resize() {
 	d = 1;
 	while (1<<d <= n) d++;
-    n = 0;
 	array<List> newTable(1<<d);
 	for (int i = 0; i < t.length; i++) {
 		for (int j = 0; j < t[i].size(); j++) {


### PR DESCRIPTION
ChainedHashTalbles objects did not return correct sizes. fixed.
# include "ChainedHashTable.h"
# include <iostream>

int main() {
  ods::ChainedHashTable<int> h;
  for (int i = 0; i < 7; i++) 
    h.add(i);
  std::cout << h.size() << std::endl;
  // '1' is printed. it must be '7'
}
