### PR TITLE
Replace broken link to Mathematics for Com-Sci

### DIFF
--- a/latex/ods.bib
+++ b/latex/ods.bib
@@ -623,7 +623,7 @@ publisher={G. Kempensem},
   author    = {E. Lehman and F. T. Leighton and A. R. Meyer},
   title     = {Mathematics for Computer Science},
   year      = {2011},
-  url       = {http://courses.csail.mit.edu/6.042/spring12/mcs.pdf},
+  url       = {http://people.csail.mit.edu/meyer/mcs.pdf},
   lastchecked= {2012-09-06}
 }
 


### PR DESCRIPTION
The current link is broken. Is this the correct link?
