### PR TITLE
Java Scapegoat BT takes too long to trigger update

### DIFF
--- a/java/ods/ScapegoatTree.java
+++ b/java/ods/ScapegoatTree.java
@@ -33,13 +33,13 @@ public class ScapegoatTree<T>
 	}
 	
 	/**
-	 * Compute the ceiling of log_{3/2}(q)
+	 * Compute the floor of log_{3/2}(q)
 	 * @param q
-	 * @return the ceiling of log_{3/2}(q)
+	 * @return the floor of log_{3/2}(q)
 	 */
 	protected static final int log32(int q) {
 		final double log23 = 2.4663034623764317;
-		return (int)Math.ceil(log23*Math.log(q));
+		return (int)Math.floor(log23*Math.log(q));
 	}
 
 	/***


### PR DESCRIPTION
Because of the ceiling function used in log32 (line:42) and the > operator in the add method (line:92). The scape goat tree waits longer than it should in order to trigger a rebuild.