### PR TITLE
Fix ArrayQueue

### DIFF
--- a/cpp/ArrayQueue.h
+++ b/cpp/ArrayQueue.h
@@ -8,6 +8,7 @@
 #ifndef ARRAYQUEUE_H_
 #define ARRAYQUEUE_H_
 #include "array.h"
+#include "utils.h"
 
 namespace ods {
 

--- a/cpp/ArrayQueue.h
+++ b/cpp/ArrayQueue.h
@@ -35,7 +35,6 @@ ArrayQueue<T>::ArrayQueue() : a(1) {
 
 template<class T>
 ArrayQueue<T>::~ArrayQueue() {
-	delete a;
 }
 
 template<class T>


### PR DESCRIPTION
There seem to be two small bugs in the ` ArrayQueue` code--the `resize()` method needs the `max()` function from the `utils` header, but the header isn't included. And the destructor deletes the `array a`, but `a` wasn't dynamically allocated to begin with. (Thanks to my students for pointing these out!)