### PR TITLE
Fix typo in SLList::Node constructor

### DIFF
--- a/cpp/SLList.h
+++ b/cpp/SLList.h
@@ -21,7 +21,7 @@ protected:
 		T x;
 		Node *next;
 		Node(T x0) {
-			x = 0;
+			x = x0;
 			next = NULL;
 		}
 	};


### PR DESCRIPTION
Current code sets `x` to `0` instead of value of `x0` parameter.