### PR TITLE
fix maximum number of leaves in b-tree from 2(2B)^{h-1} to (2B)^{h}

### DIFF
--- a/latex/btree.tex
+++ b/latex/btree.tex
@@ -158,7 +158,7 @@ relaxed at the root, which can have anywhere between 2 and $2B$ children.
 If the height of a $B$-tree is $h$, then it follows that the number,
 $\ell$, of leaves in the $B$-tree satisfies
 \[
-    2B^{h-1} \le \ell \le 2(2B)^{h-1} \enspace .
+    2B^{h-1} \le \ell \le (2B)^{h} \enspace .
 \]
 Taking the logarithm of the first inequality and rearranging terms yields:
 \begin{align*}


### PR DESCRIPTION
When all nodes except leaves have 2B children, b-tree should have the maximum number of leaves.

Reference: http://orca.st.usm.edu/~seyfarth/csc738/btree_size/btree.pdf