### PR TITLE
removed a redundant (unmatched) right parenthesis

### DIFF
--- a/latex/hashing.tex
+++ b/latex/hashing.tex
@@ -773,7 +773,7 @@ the small amount of randomization needed to choose #z#:
   one index $i\in\{0,\ldots,r-1\}$. Then
   \[
      \Pr\{ h(#x#_0,\ldots,#x#_{r-1}) =  h(#y#_0,\ldots,#y#_{r-1}) \} 
-          \le (r-1)/#p# \} \enspace .  
+          \le (r-1)/#p# \enspace .
   \] 
 \end{thm}
 


### PR DESCRIPTION
This commit removes an unmatched right parenthesis.