### PR TITLE
Fixed range of i in exercise2.4

### DIFF
--- a/latex/arrays.tex
+++ b/latex/arrays.tex
@@ -1057,7 +1057,7 @@ of a #RootishArrayStack# discussed in \excref{rootisharraystack-fast}.
 \begin{exc}
   Implement a method #rotate(a,r)# that ``rotates'' the array #a#
   so that #a[i]# moves to $#a#[(#i#+#r#)\bmod #a.length#]$, for all
-  $#i#\in\{0,\ldots,#a.length#\}$.
+  $#i#\in\{0,\ldots,#a.length-1#\}$.
 \end{exc}
 
 \begin{exc}


### PR DESCRIPTION
Not a very big deal at all, but note this is a slight miss.
I think the range of i is `a.length-1` in exercise2.4.